### PR TITLE
Adding Upstream-contact information

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: application-connector-manager
-Upstream-Contact: 
+Upstream-Contact: Framefrog Team <team-framefrog@sap.com>
 Source: https://github.com/kyma-project/application-connector-manager
 Disclaimer: The code in this project may include calls to APIs (“API Calls”) of
  SAP or third-party products or services developed outside of this project


### PR DESCRIPTION
Adding Framefrog team email as an Upstream-Contact for the repository.