### PR TITLE
Use default TLS configuration in application-connector Istio gateway

### DIFF
--- a/application-connector-dependencies.yaml
+++ b/application-connector-dependencies.yaml
@@ -22,14 +22,7 @@ spec:
       number: 443
       protocol: HTTPS
     tls:
-      cipherSuites:
-      - ECDHE-RSA-CHACHA20-POLY1305
-      - ECDHE-RSA-AES256-GCM-SHA384
-      - ECDHE-RSA-AES256-SHA
-      - ECDHE-RSA-AES128-GCM-SHA256
-      - ECDHE-RSA-AES128-SHA
       credentialName: kyma-gateway-certs
-      minProtocolVersion: TLSV1_2
       mode: MUTUAL
 ---
 apiVersion: networking.istio.io/v1beta1


### PR DESCRIPTION
Since Kyma 2.15 ECDHE-RSA-AES256-SHA and ECDHE-RSA-AES128-SHA cipher suites are deprecated and Kyma security team recommendation. Remove cipher suites configuration from TLS on kyma gateway since envoy is already [configuring cipher suites](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto) by default. Remove minProtocolVersion since it's redundant to [istio default configuration](https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings). 