### PR TITLE
Change eventing publisher service endpoint to eventing-publisher-proxy.kyma-system

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 ifndef MODULE_VERSION
-    MODULE_VERSION = 1.0.2
+    MODULE_VERSION = 1.0.4
 endif

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
 # Default owners of the repository
-* @VOID404 @akgalwas @koala7659 @m00g3n @mvshao
+* @kyma-project/Framefrog
 
 # All files and subdirectories in /docs
-/docs/ @mmitoraj @NHingerl @grego952 @IwonaLanger @nataliasitko
+/docs/ @kyma-project/technical-writers
 
 # All .md files
-*.md @mmitoraj @NHingerl @grego952 @IwonaLanger @nataliasitko
+*.md @kyma-project/technical-writers

--- a/application-connector.yaml
+++ b/application-connector.yaml
@@ -259,7 +259,7 @@ spec:
           - "--externalAPIPort=8081"
           - "--eventingPathPrefixV1=/%%APP_NAME%%/v1/events"
           - "--eventingPathPrefixV2=/%%APP_NAME%%/v2/events"
-          - "--eventingPublisherHost=eventing-event-publisher-proxy.kyma-system"
+          - "--eventingPublisherHost=eventing-publisher-proxy.kyma-system"
           - "--eventingDestinationPath=/publish"
           - "--eventingPathPrefixEvents=/%%APP_NAME%%/events"
           - "--appNamePlaceholder=%%APP_NAME%%"


### PR DESCRIPTION
This PR updates `central-application-connectivity-validator` configuration with name of endpoint used for delivering proxied events changed from `eventing-event-publisher-proxy.kyma-system` to `eventing-publisher-proxy.kyma-system`.

The reason is align with latest eventing modules changes where the old service was removed. 

This change should not have any imact on functionality. 
The new endpoint should deliver events to target eventing subscriptions like the previous one.