### PR TITLE
Update security scanner image to latest version from registry

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,6 +1,6 @@
 module-name: application-connector-manager
 protecode:
-  - europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:v20231026-f05f0208
+  - europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:v20231124-a0ea0afb
 whitesource:
   language: golang-mod
   subprojects: false


### PR DESCRIPTION
Update secscanner file for release 1.0.4 with image v20231124-a0ea0afb from [repository](https://console.cloud.google.com/artifacts/docker/kyma-project/europe/prod/application-connector-manager) after merging [PR 111](https://github.com/kyma-project/application-connector-manager/pull/111) 