### PR TITLE
bumps k3d version to 5.6.0

### DIFF
--- a/.github/workflows/kyma-integration-k3d-agent-tests.yml
+++ b/.github/workflows/kyma-integration-k3d-agent-tests.yml
@@ -15,7 +15,7 @@ jobs:
     # it could cause the secret leakeages
     uses: "./.github/workflows/reusable-k3d-agent-test.yml"
     with:
-      k3d-version: v5.4.6
+      k3d-version: v5.6.0
     secrets:
       compass-host: ${{ secrets.COMPASS_HOST }}
       compass-client-id: ${{ secrets.COMPASS_CLIENT_ID }}

--- a/.github/workflows/kyma-integration-k3d-app-gateway.yml
+++ b/.github/workflows/kyma-integration-k3d-app-gateway.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install k3d
         env:
           K3D_URL: https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh
-          DEFAULT_K3D_VERSION: v5.4.6
+          DEFAULT_K3D_VERSION: v5.6.0
         run: curl --silent --fail $K3D_URL | TAG=$DEFAULT_K3D_VERSION bash
       - name: Set up cache
         uses: actions/cache@v3

--- a/.github/workflows/kyma-integration-k3d-validator-tests.yml
+++ b/.github/workflows/kyma-integration-k3d-validator-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install k3d
         env:
           K3D_URL: https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh
-          DEFAULT_K3D_VERSION: v5.4.6
+          DEFAULT_K3D_VERSION: v5.6.0
         run: curl --silent --fail $K3D_URL | TAG=$DEFAULT_K3D_VERSION bash
       - name: Insall yq
         run: sudo add-apt-repository ppa:rmescandon/yq && sudo apt update && sudo apt install yq -y

--- a/.github/workflows/reusable-k3d-agent-test.yml
+++ b/.github/workflows/reusable-k3d-agent-test.yml
@@ -5,7 +5,7 @@ on:
        k3d-version:
          required: true
          type: string
-         default: v5.4.6
+         default: v5.6.0
     secrets:
       compass-host:
         required: true

--- a/hack/ci/Makefile
+++ b/hack/ci/Makefile
@@ -2,7 +2,7 @@ PROJECT_ROOT ?= ../..
 PROJECT_COMMON ?= ../common
 
 K3D_URL=https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh
-DEFAULT_K3D_VERSION=v5.4.6
+DEFAULT_K3D_VERSION=v5.6.0
 
 include ${PROJECT_ROOT}/.env
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bumps k3d version to 5.6.0 in order to fix CRA k3d test 
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
