### PR TITLE
fix: Change timestamp format for logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func main() {
 	config := zap.NewDevelopmentConfig()
 	config.EncoderConfig.TimeKey = "timestamp"
 	config.Encoding = "json"
-	config.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout("Jan 02 15:04:05.000000000")
+	config.EncoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
 
 	appConLogger, err := config.Build()
 	if err != nil {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Change the timestamp format for logs from `May 15 12:12:14.044359670` to `2024-05-15T12:12:14Z`

Manager logs before change:
```
➜  application-connector-manager git:(main) ✗ k logs -n kyma-system application-connector-controller-manager-649fbc9bb5-9xnh6
{"level":"info","ts":"2024-05-15T12:12:14Z","logger":"setup","msg":"log level set to: debug"}
{"L":"INFO","timestamp":"May 15 12:12:14.044359670","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"apiextensions.k8s.io/v1, Kind=CustomResourceDefinition"}
{"L":"INFO","timestamp":"May 15 12:12:14.045027337","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"/v1, Kind=ServiceAccount"}
{"L":"INFO","timestamp":"May 15 12:12:14.045077753","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"rbac.authorization.k8s.io/v1, Kind=ClusterRole"}
{"L":"INFO","timestamp":"May 15 12:12:14.045088295","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding"}
{"L":"INFO","timestamp":"May 15 12:12:14.045097295","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"/v1, Kind=Service"}
{"L":"INFO","timestamp":"May 15 12:12:14.045113003","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"scheduling.k8s.io/v1, Kind=PriorityClass"}
{"L":"INFO","timestamp":"May 15 12:12:14.045125045","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"apps/v1, Kind=Deployment"}
{"L":"INFO","timestamp":"May 15 12:12:14.045141587","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"autoscaling/v2, Kind=HorizontalPodAutoscaler"}
{"L":"INFO","timestamp":"May 15 12:12:14.045151795","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"/v1, Kind=ConfigMap"}
{"L":"INFO","timestamp":"May 15 12:12:14.045166378","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"rbac.authorization.k8s.io/v1, Kind=Role"}
{"L":"INFO","timestamp":"May 15 12:12:14.045179712","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"rbac.authorization.k8s.io/v1, Kind=RoleBinding"}
{"level":"info","ts":"2024-05-15T12:12:14Z","logger":"setup","msg":"starting manager"}
{"level":"info","ts":"2024-05-15T12:12:14Z","logger":"controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"starting server","kind":"health probe","addr":"[::]:8081"}
{"level":"info","ts":"2024-05-15T12:12:14Z","logger":"controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8080","secure":false}
I0515 12:12:14.053204       1 leaderelection.go:250] attempting to acquire leader lease kyma-system/3e432b4e.acm.operator.kyma-project.io...
I0515 12:12:14.147344       1 leaderelection.go:260] successfully acquired lease kyma-system/3e432b4e.acm.operator.kyma-project.io
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *v1alpha1.ApplicationConnector"}
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *v1.Secret"}
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"Starting Controller","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector"}
I0515 12:12:14.745468       1 trace.go:236] Trace[1140828605]: "DeltaFIFO Pop Process" ID:default/default,Depth:40,Reason:slow event handlers blocking the queue (15-May-2024 12:12:14.545) (total time: 195ms):
Trace[1140828605]: [195.871542ms] [195.871542ms] END
I0515 12:12:14.745530       1 trace.go:236] Trace[1711537057]: "DeltaFIFO Pop Process" ID:application-connector-manager-rolebinding,Depth:53,Reason:slow event handlers blocking the queue (15-May-2024 12:12:14.633) (total time: 106ms):
Trace[1711537057]: [106.06525ms] [106.06525ms] END
{"level":"info","ts":"2024-05-15T12:12:14Z","msg":"Starting workers","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","worker count":1}
```

Manager logs after change:
```
➜  application-connector-manager git:(fix_logs_timestamp_format) ✗ k logs -n kyma-system application-connector-controller-manager-654647c9fb-gsq5q
{"level":"info","ts":"2024-05-15T12:19:15Z","logger":"setup","msg":"log level set to: debug"}
{"L":"INFO","timestamp":"2024-05-15T12:19:15Z","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"apiextensions.k8s.io/v1, Kind=CustomResourceDefinition"}
{"L":"INFO","timestamp":"2024-05-15T12:19:15Z","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"/v1, Kind=ServiceAccount"}
{"L":"INFO","timestamp":"2024-05-15T12:19:15Z","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"rbac.authorization.k8s.io/v1, Kind=ClusterRole"}
{"L":"INFO","timestamp":"2024-05-15T12:19:15Z","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding"}
{"L":"INFO","timestamp":"2024-05-15T12:19:15Z","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"/v1, Kind=Service"}
{"L":"INFO","timestamp":"2024-05-15T12:19:15Z","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"scheduling.k8s.io/v1, Kind=PriorityClass"}
{"L":"INFO","timestamp":"2024-05-15T12:19:15Z","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"apps/v1, Kind=Deployment"}
{"L":"INFO","timestamp":"2024-05-15T12:19:15Z","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"autoscaling/v2, Kind=HorizontalPodAutoscaler"}
{"L":"INFO","timestamp":"2024-05-15T12:19:15Z","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"/v1, Kind=ConfigMap"}
{"L":"INFO","timestamp":"2024-05-15T12:19:15Z","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"rbac.authorization.k8s.io/v1, Kind=Role"}
{"L":"INFO","timestamp":"2024-05-15T12:19:15Z","C":"controllers/applicationconnector_controller.go:212","M":"adding watcher","gvk":"rbac.authorization.k8s.io/v1, Kind=RoleBinding"}
{"level":"info","ts":"2024-05-15T12:19:15Z","logger":"setup","msg":"starting manager"}
{"level":"info","ts":"2024-05-15T12:19:15Z","logger":"controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2024-05-15T12:19:15Z","msg":"starting server","kind":"health probe","addr":"[::]:8081"}
{"level":"info","ts":"2024-05-15T12:19:15Z","logger":"controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8080","secure":false}
I0515 12:19:15.246494       1 leaderelection.go:250] attempting to acquire leader lease kyma-system/3e432b4e.acm.operator.kyma-project.io...
I0515 12:19:41.067767       1 leaderelection.go:260] successfully acquired lease kyma-system/3e432b4e.acm.operator.kyma-project.io
{"level":"info","ts":"2024-05-15T12:19:41Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *v1alpha1.ApplicationConnector"}
{"level":"info","ts":"2024-05-15T12:19:41Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:19:41Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:19:41Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:19:41Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:19:41Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:19:41Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:19:41Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:19:41Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:19:41Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:19:41Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:19:41Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2024-05-15T12:19:41Z","msg":"Starting EventSource","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","source":"kind source: *v1.Secret"}
{"level":"info","ts":"2024-05-15T12:19:41Z","msg":"Starting Controller","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector"}
{"level":"info","ts":"2024-05-15T12:19:41Z","msg":"Starting workers","controller":"applicationconnector","controllerGroup":"operator.kyma-project.io","controllerKind":"ApplicationConnector","worker count":1}
```


**Related issue(s)**
#242 
