### PR TITLE
Configuration of the application-connector module for new release 1.1.7

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 ifndef MODULE_VERSION
-    MODULE_VERSION = 1.1.6
+    MODULE_VERSION = 1.1.7
 endif

--- a/application-connector.yaml
+++ b/application-connector.yaml
@@ -251,7 +251,7 @@ spec:
       serviceAccountName: central-application-connectivity-validator
       containers:
         - name: central-application-connectivity-validator
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:v20240613-2d81da38
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:v20240910-57c6730a
           imagePullPolicy: IfNotPresent
           args:
             - "/app/centralapplicationconnectivityvalidator"
@@ -332,7 +332,7 @@ spec:
       serviceAccountName: central-application-gateway
       containers:
         - name: central-application-gateway
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:v20240613-2d81da38
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:v20240910-57c6730a
           imagePullPolicy: IfNotPresent
           args:
             - "/app/applicationgateway"
@@ -1029,7 +1029,7 @@ spec:
             - containerPort: 8090
               hostPort: 0
               name: http-health
-          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:v20240613-ede06287
+          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:v20240910-57c6730a
           imagePullPolicy: IfNotPresent
           args:
             - "/app/compass-runtime-agent"

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,9 +1,9 @@
 module-name: application-connector-manager
 protecode:
-  - europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.1.6
-  - europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:v20240613-2d81da38
-  - europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:v20240613-2d81da38
-  - europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:v20240613-ede06287
+  - europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.1.7
+  - europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:v20240910-57c6730a
+  - europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:v20240910-57c6730a
+  - europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:v20240910-57c6730a
 whitesource:
   language: golang-mod
   subprojects: false


### PR DESCRIPTION
- New release version 1.1.7 is set as MODULE_VERSION
- Latest component images used in 
  - module helm manifest file
  - sec-scanners-config file