### PR TITLE
Fix of golangci-lint gh action

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -22,12 +22,12 @@ jobs:
           go-version: '1.23.0'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.0.0
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 #v6.1.0
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.58.2
+          version: 1.61.0
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
@@ -37,7 +37,7 @@ jobs:
           # Note: By default, the `.golangci.yml` file should be at the root of the repository.
           # The location of the configuration file can be changed by using `--config=`
           # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0 
-          args: --timeout=5m
+          args: --timeout=10m --verbose
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
@@ -45,9 +45,6 @@ jobs:
           # Optional: if set to true, then all caching functionality will be completely disabled,
           #           takes precedence over all other caching options.
           # skip-cache: true
-
-          # Optional: if set to true, then the action won't cache or restore ~/go/pkg.
-          skip-pkg-cache: true
 
           # Optional: if set to true, then the action won't cache or restore ~/.cache/go-build.
           # skip-build-cache: true

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -27,7 +27,7 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: 1.61.0
+          version: v1.61.0
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir


### PR DESCRIPTION
**Description**

Updated `golangci-lint ` GH action:

- use latest verstion 6.1.0
- change version format to SHA tag, to ensure safety, 
- use new version of golangci-lint
- increasing timeout to 10m
- remove obsolete parameter