### PR TITLE
Update Golang version to 1.23.1

### DIFF
--- a/.github/workflows/gateway.yaml
+++ b/.github/workflows/gateway.yaml
@@ -109,7 +109,7 @@ jobs:
       - name: Set up go environment
         uses: actions/setup-go@v4
         with:
-          go-version: 1.23.0
+          go-version: 1.23.1
       - name: Install k3d
         env:
           K3D_URL: https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.0'
+          go-version: '1.23.1'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 #v6.1.0

--- a/.github/workflows/reusable-k3d-agent-test.yml
+++ b/.github/workflows/reusable-k3d-agent-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up go environment
         uses: actions/setup-go@v4
         with:
-          go-version: 1.23.0
+          go-version: 1.23.1
       - name: install-k3d
         env:
           K3D_URL: https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh

--- a/.github/workflows/run-validation.yaml
+++ b/.github/workflows/run-validation.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up go environment
       uses: actions/setup-go@v4
       with:
-        go-version: 1.23.0
+        go-version: 1.23.1
 
     - name: Run integration tests without lifecycle-manager
       run: make -C hack/ci run-without-lifecycle-manager

--- a/.github/workflows/run-vuln-check.yaml
+++ b/.github/workflows/run-vuln-check.yaml
@@ -15,5 +15,5 @@ jobs:
     - name: vulncheck
       uses: golang/govulncheck-action@v1
       with:
-        go-version-input: 1.23.0
+        go-version-input: 1.23.1
         go-package: ./...

--- a/.github/workflows/validator.yaml
+++ b/.github/workflows/validator.yaml
@@ -106,7 +106,7 @@ jobs:
       - name: Set up go environment
         uses: actions/setup-go@v4
         with:
-          go-version: 1.23.0
+          go-version: 1.23.1
       - name: Install k3d
         env:
           K3D_URL: https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23.0-alpine3.20 as builder
+FROM golang:1.23.1-alpine3.20 as builder
 
 WORKDIR /acm-workspace
 

--- a/components/central-application-connectivity-validator/Dockerfile
+++ b/components/central-application-connectivity-validator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine3.20 as builder
+FROM golang:1.23.1-alpine3.20 as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/central-application-connectivity-validator
 WORKDIR $DOCK_PKG_DIR

--- a/components/central-application-connectivity-validator/go.mod
+++ b/components/central-application-connectivity-validator/go.mod
@@ -1,8 +1,6 @@
 module github.com/kyma-project/kyma/components/central-application-connectivity-validator
 
-go 1.23.0
-
-toolchain go1.23.1
+go 1.23.1
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/components/central-application-connectivity-validator/go.mod
+++ b/components/central-application-connectivity-validator/go.mod
@@ -1,8 +1,8 @@
 module github.com/kyma-project/kyma/components/central-application-connectivity-validator
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.0
+toolchain go1.23.1
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/components/central-application-gateway/Dockerfile
+++ b/components/central-application-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine3.20 as builder
+FROM golang:1.23.1-alpine3.20 as builder
 
 ARG DOCK_PKG_DIR=/go/src/github.com/kyma-project/kyma/components/central-application-gateway
 WORKDIR $DOCK_PKG_DIR

--- a/components/central-application-gateway/go.mod
+++ b/components/central-application-gateway/go.mod
@@ -1,8 +1,8 @@
 module github.com/kyma-project/kyma/components/central-application-gateway
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.0
+toolchain go1.23.1
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/components/central-application-gateway/go.mod
+++ b/components/central-application-gateway/go.mod
@@ -1,8 +1,6 @@
 module github.com/kyma-project/kyma/components/central-application-gateway
 
-go 1.23.0
-
-toolchain go1.23.1
+go 1.23.1
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/components/compass-runtime-agent/Dockerfile
+++ b/components/compass-runtime-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine3.20 as builder
+FROM golang:1.23.1-alpine3.20 as builder
 
 
 ARG DOCK_PKG_DIR=/compass-runtime-agent

--- a/components/compass-runtime-agent/go.mod
+++ b/components/compass-runtime-agent/go.mod
@@ -1,8 +1,6 @@
 module github.com/kyma-project/kyma/components/compass-runtime-agent
 
-go 1.23.0
-
-toolchain go1.23.1
+go 1.23.1
 
 require (
 	github.com/google/uuid v1.6.0

--- a/components/compass-runtime-agent/go.mod
+++ b/components/compass-runtime-agent/go.mod
@@ -1,8 +1,8 @@
 module github.com/kyma-project/kyma/components/compass-runtime-agent
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.0
+toolchain go1.23.1
 
 require (
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/kyma-project/application-connector-manager
 
 go 1.23.0
 
+toolchain go1.23.1
+
 require (
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.2

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/kyma-project/application-connector-manager
 
-go 1.23.0
-
-toolchain go1.23.1
+go 1.23.1
 
 require (
 	github.com/onsi/ginkgo/v2 v2.20.1

--- a/tests/Dockerfile.compass-runtime-agent
+++ b/tests/Dockerfile.compass-runtime-agent
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine as builder
+FROM golang:1.23.1-alpine3.20 as builder
 
 WORKDIR /compass-test/
 

--- a/tests/Dockerfile.connectivity-validator
+++ b/tests/Dockerfile.connectivity-validator
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine as builder
+FROM golang:1.23.1-alpine3.20 as builder
 
 WORKDIR /validator-test/
 

--- a/tests/Dockerfile.gateway
+++ b/tests/Dockerfile.gateway
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine as builder
+FROM golang:1.23.1-alpine3.20 as builder
 
 WORKDIR /gateway-test/
 

--- a/tests/Dockerfile.mockapp
+++ b/tests/Dockerfile.mockapp
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine as builder
+FROM golang:1.23.1-alpine3.20 as builder
 
 WORKDIR /mock-app/
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/kyma/tests/components/application-connector
 
-go 1.22.3
+go 1.23.1
 
 require (
 	github.com/avast/retry-go v3.0.0+incompatible


### PR DESCRIPTION
**Changes proposed in this pull request:**

- change of Docker builder images to golang:1.23.1-alpine3.20
- update go version in `go.mod` files to 1.23.1 
- Update  go version for GH Actions to 1.23.1 
