### PR TITLE
Increasing minimal number of pod replicas for gateway and validator deployment to 2

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 ifndef MODULE_VERSION
-    MODULE_VERSION = 1.1.9
+    MODULE_VERSION = 1.1.10
 endif

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 ifndef MODULE_VERSION
-    MODULE_VERSION = 1.1.8
+    MODULE_VERSION = 1.1.9
 endif

--- a/application-connector.yaml
+++ b/application-connector.yaml
@@ -390,8 +390,8 @@ metadata:
     app.kubernetes.io/instance: application-connector
     app.kubernetes.io/part-of: application-connector-manager
 spec:
-  minReplicas: 1
-  maxReplicas: 1
+  minReplicas: 2
+  maxReplicas: 2
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
@@ -418,8 +418,8 @@ metadata:
     app.kubernetes.io/instance: application-connector
     app.kubernetes.io/part-of: application-connector-manager
 spec:
-  minReplicas: 1
-  maxReplicas: 1
+  minReplicas: 2
+  maxReplicas: 2
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/application-connector.yaml
+++ b/application-connector.yaml
@@ -248,6 +248,13 @@ spec:
         app.kubernetes.io/part-of: application-connector-manager
         release: application-connector
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "topology.kubernetes.io/zone"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: central-application-connectivity-validator
       serviceAccountName: central-application-connectivity-validator
       containers:
         - name: central-application-connectivity-validator
@@ -329,6 +336,13 @@ spec:
         app.kubernetes.io/part-of: application-connector-manager
         release: application-connector
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "topology.kubernetes.io/zone"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: central-application-gateway
       serviceAccountName: central-application-gateway
       containers:
         - name: central-application-gateway

--- a/application-connector.yaml
+++ b/application-connector.yaml
@@ -251,7 +251,7 @@ spec:
       serviceAccountName: central-application-connectivity-validator
       containers:
         - name: central-application-connectivity-validator
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:v20240920-8cc34ee6
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:v20250403-2fe746fb
           imagePullPolicy: IfNotPresent
           args:
             - "/app/centralapplicationconnectivityvalidator"
@@ -332,7 +332,7 @@ spec:
       serviceAccountName: central-application-gateway
       containers:
         - name: central-application-gateway
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:v20240920-8cc34ee6
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:v20250403-2fe746fb
           imagePullPolicy: IfNotPresent
           args:
             - "/app/applicationgateway"

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,7 +1,7 @@
 module-name: application-connector-manager
 kind: kyma
 bdba:
-  - europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.1.9
+  - europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.1.10
   - europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:v20250403-2fe746fb
   - europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:v20250403-2fe746fb
   - europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:v20250404-e64a8df5

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,10 +1,10 @@
 module-name: application-connector-manager
 kind: kyma
 bdba:
-  - europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.1.8
-  - europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:v20240920-8cc34ee6
-  - europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:v20240920-8cc34ee6
-  - europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:v20240920-8cc34ee6
+  - europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.1.9
+  - europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:v20250403-2fe746fb
+  - europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:v20250403-2fe746fb
+  - europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:v20250404-e64a8df5
 mend:
   language: golang-mod
   exclude:


### PR DESCRIPTION
Test release 1.1.10 only for Dev channel. 