### PR TITLE
Bump images to 1.1.17

### DIFF
--- a/application-connector.yaml
+++ b/application-connector.yaml
@@ -258,7 +258,7 @@ spec:
       serviceAccountName: central-application-connectivity-validator
       containers:
         - name: central-application-connectivity-validator
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.1.13
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.1.17
           imagePullPolicy: IfNotPresent
           args:
             - "/app/centralapplicationconnectivityvalidator"
@@ -346,7 +346,7 @@ spec:
       serviceAccountName: central-application-gateway
       containers:
         - name: central-application-gateway
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.1.13
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.1.17
           imagePullPolicy: IfNotPresent
           args:
             - "/app/applicationgateway"
@@ -1038,7 +1038,7 @@ spec:
             - containerPort: 8090
               hostPort: 0
               name: http-health
-          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.1.13
+          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.1.17
           imagePullPolicy: IfNotPresent
           args:
             - "/app/compass-runtime-agent"

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,15 +1,19 @@
 module-name: application-connector-manager
 kind: kyma
 bdba:
+  - europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.1.17
   - europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:latest
+  - europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.1.17
   - europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:latest
+  - europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.1.17
   - europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:latest
+  - europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.1.17
   - europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:latest
 mend:
   language: golang-mod
   exclude:
-    - "**/*_test.go"
+    - '**/*_test.go'
 checkmarx-one:
   preset: go-default
   exclude:
-    - "**/*_test.go"
+    - '**/*_test.go'


### PR DESCRIPTION
[![ACM](https://github.com/kyma-project/application-connector-manager/actions/workflows/acm.yaml/badge.svg?branch=main&event=push)](https://github.com/kyma-project/application-connector-manager/actions/workflows/acm.yaml) [![Bump images on tag push](https://github.com/kyma-project/application-connector-manager/actions/workflows/bump-images.yaml/badge.svg?event=push)](https://github.com/kyma-project/application-connector-manager/actions/workflows/bump-images.yaml)
# Bumped images
- `europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.1.17`
- `europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.1.17`
- `europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.1.17`
- `europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.1.17`
