### PR TITLE
Use correct value of securityContext.procMount for CRA deployment

### DIFF
--- a/application-connector.yaml
+++ b/application-connector.yaml
@@ -1032,7 +1032,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-            procMount: default
+            procMount: Default
             readOnlyRootFilesystem: true
           ports:
             - containerPort: 8090


### PR DESCRIPTION
Change of the value from "default" to "Default"

This should fix problem with compatibility for Kubernetes 1.33 