### PR TITLE
Set gate job as required for other jobs in workflows

### DIFF
--- a/.github/workflows/controller.yaml
+++ b/.github/workflows/controller.yaml
@@ -52,6 +52,7 @@ jobs:
 
   setup-and-tests:
     needs: [gate]
+    if: needs.gate.result == 'success' || needs.gate.result == 'skipped'
     uses: ./.github/workflows/controller-tests.yaml
 
   build-image:
@@ -69,7 +70,7 @@ jobs:
 
   print-images:
     runs-on: ubuntu-latest
-    needs: [build-image, gate]
+    needs: [build-image]
     if: always() && contains(needs.*.result, 'success')
     steps:
       - name: "Generate summary"

--- a/.github/workflows/controller.yaml
+++ b/.github/workflows/controller.yaml
@@ -51,6 +51,7 @@ jobs:
         run: echo "Image build approved for fork PR"
 
   setup-and-tests:
+    needs: [gate]
     uses: ./.github/workflows/controller-tests.yaml
 
   build-image:
@@ -68,7 +69,7 @@ jobs:
 
   print-images:
     runs-on: ubuntu-latest
-    needs: [build-image]
+    needs: [build-image, gate]
     if: always() && contains(needs.*.result, 'success')
     steps:
       - name: "Generate summary"

--- a/.github/workflows/cra.yaml
+++ b/.github/workflows/cra.yaml
@@ -41,8 +41,9 @@ jobs:
     steps:
       - name: Approve fork PR image build
         run: echo "Image build approved for fork PR"
-
+  
   setup-and-test:
+    needs: [gate]
     uses: ./.github/workflows/cra-tests.yaml
     secrets:
       COMPASS_HOST: ${{ secrets.COMPASS_HOST }}
@@ -50,6 +51,7 @@ jobs:
       COMPASS_CLIENT_SECRET: ${{ secrets.COMPASS_CLIENT_SECRET }}
 
   tags:
+    needs: [gate]
     runs-on: ubuntu-latest
     outputs:
       latest: ${{ steps.latest.outputs.latest || '' }}
@@ -62,7 +64,7 @@ jobs:
     # we're using reusable because we can't modify workflows as contributors
     # it could cause the secret leakeages
     uses: "./.github/workflows/reusable-k3d-agent-test.yaml"
-    needs: build-image
+    needs: [build-image, gate]
     if: needs.build-image.result == 'success'
     with:
       k3d-version: v5.8.3
@@ -101,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # if any of the build jobs succeeded - run this job
-    needs: [build-image, build-test-image]
+    needs: [build-image, build-test-image, gate]
     if: always() && contains(needs.*.result, 'success')
 
     steps:

--- a/.github/workflows/cra.yaml
+++ b/.github/workflows/cra.yaml
@@ -44,6 +44,7 @@ jobs:
   
   setup-and-test:
     needs: [gate]
+    if: needs.gate.result == 'success' || needs.gate.result == 'skipped'
     uses: ./.github/workflows/cra-tests.yaml
     secrets:
       COMPASS_HOST: ${{ secrets.COMPASS_HOST }}
@@ -52,6 +53,7 @@ jobs:
 
   tags:
     needs: [gate]
+    if: needs.gate.result == 'success' || needs.gate.result == 'skipped'
     runs-on: ubuntu-latest
     outputs:
       latest: ${{ steps.latest.outputs.latest || '' }}
@@ -64,7 +66,7 @@ jobs:
     # we're using reusable because we can't modify workflows as contributors
     # it could cause the secret leakeages
     uses: "./.github/workflows/reusable-k3d-agent-test.yaml"
-    needs: [build-image, gate]
+    needs: [build-image]
     if: needs.build-image.result == 'success'
     with:
       k3d-version: v5.8.3
@@ -103,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # if any of the build jobs succeeded - run this job
-    needs: [build-image, build-test-image, gate]
+    needs: [build-image, build-test-image]
     if: always() && contains(needs.*.result, 'success')
 
     steps:

--- a/.github/workflows/gateway.yaml
+++ b/.github/workflows/gateway.yaml
@@ -41,9 +41,11 @@ jobs:
         run: echo "Image build approved for fork PR"
 
   setup-and-test:
+    needs: [gate]
     uses: ./.github/workflows/gateway-tests.yaml
 
   tags:
+    needs: [gate]
     runs-on: ubuntu-latest
     outputs:
       latest: ${{ steps.latest.outputs.latest || '' }}
@@ -91,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # if any of the build jobs succeeded - run this job
-    needs: [build-image, build-test-image, build-mock-app-image]
+    needs: [build-image, build-test-image, build-mock-app-image, gate]
     if: always() && contains(needs.*.result, 'success')
 
     steps:

--- a/.github/workflows/gateway.yaml
+++ b/.github/workflows/gateway.yaml
@@ -42,10 +42,12 @@ jobs:
 
   setup-and-test:
     needs: [gate]
+    if: needs.gate.result == 'success' || needs.gate.result == 'skipped'
     uses: ./.github/workflows/gateway-tests.yaml
 
   tags:
     needs: [gate]
+    if: needs.gate.result == 'success' || needs.gate.result == 'skipped'
     runs-on: ubuntu-latest
     outputs:
       latest: ${{ steps.latest.outputs.latest || '' }}
@@ -93,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # if any of the build jobs succeeded - run this job
-    needs: [build-image, build-test-image, build-mock-app-image, gate]
+    needs: [build-image, build-test-image, build-mock-app-image]
     if: always() && contains(needs.*.result, 'success')
 
     steps:

--- a/.github/workflows/validator.yaml
+++ b/.github/workflows/validator.yaml
@@ -42,10 +42,12 @@ jobs:
 
   setup-and-test:
     needs: [gate]
+    if: needs.gate.result == 'success' || needs.gate.result == 'skipped'
     uses: ./.github/workflows/validator-tests.yaml
 
   tags:
     needs: [gate]
+    if: needs.gate.result == 'success' || needs.gate.result == 'skipped'
     runs-on: ubuntu-latest
     outputs:
       latest: ${{ steps.latest.outputs.latest || '' }}
@@ -82,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # if any of the build jobs succeeded - run this job
-    needs: [build-image, build-test-image, gate]
+    needs: [build-image, build-test-image]
     if: always() && contains(needs.*.result, 'success')
 
     steps:

--- a/.github/workflows/validator.yaml
+++ b/.github/workflows/validator.yaml
@@ -41,9 +41,11 @@ jobs:
         run: echo "Image build approved for fork PR"
 
   setup-and-test:
+    needs: [gate]
     uses: ./.github/workflows/validator-tests.yaml
 
   tags:
+    needs: [gate]
     runs-on: ubuntu-latest
     outputs:
       latest: ${{ steps.latest.outputs.latest || '' }}
@@ -80,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # if any of the build jobs succeeded - run this job
-    needs: [build-image, build-test-image]
+    needs: [build-image, build-test-image, gate]
     if: always() && contains(needs.*.result, 'success')
 
     steps:


### PR DESCRIPTION
# Set `gate` Job as Required Dependency Across All Workflows

### Chore

🔧 Ensured the `gate` job is an explicit required dependency for all downstream jobs across multiple GitHub Actions workflows. This strengthens fork PR protection by preventing any job from running until the gate check has been evaluated (either approved or skipped for non-fork PRs).

Previously, some jobs only depended on `gate` indirectly through other jobs (e.g., via `build-image`). By explicitly adding `gate` to the `needs` list of all relevant jobs, the workflows now guarantee that no job can bypass the fork approval gate — even if the dependency chain changes in the future.

### Changes

* `.github/workflows/controller.yaml`: Added `gate` as an explicit dependency to `setup-and-tests` job with appropriate `if` condition.
* `.github/workflows/cra.yaml`: Added `gate` as an explicit dependency to `setup-and-test` and `tags` jobs; also normalized `k3d-PR-integration` needs from a scalar to array format (`needs: build-image` → `needs: [build-image]`).
* `.github/workflows/gateway.yaml`: Added `gate` as an explicit dependency to `setup-and-test` and `tags` jobs.
* `.github/workflows/validator.yaml`: Added `gate` as an explicit dependency to `setup-and-test` and `tags` jobs.

All newly added dependencies include the guard condition:
```yaml
if: needs.gate.result == 'success' || needs.gate.result == 'skipped'
```
This ensures jobs run normally for non-fork PRs (where `gate` is skipped) while requiring explicit approval for fork PRs.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `fd17f43a-8743-4790-8493-1d2b42268413`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.edited`
- LLM: `anthropic--claude-4.6-sonnet`
</details>
