### PR TITLE
Fix condition to run workflow jobs dependent on the gate job

### DIFF
--- a/.github/workflows/controller.yaml
+++ b/.github/workflows/controller.yaml
@@ -52,7 +52,7 @@ jobs:
 
   setup-and-tests:
     needs: [gate]
-    if: needs.gate.result == 'success' || needs.gate.result == 'skipped'
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     uses: ./.github/workflows/controller-tests.yaml
 
   build-image:

--- a/.github/workflows/cra.yaml
+++ b/.github/workflows/cra.yaml
@@ -44,7 +44,7 @@ jobs:
   
   setup-and-test:
     needs: [gate]
-    if: needs.gate.result == 'success' || needs.gate.result == 'skipped'
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     uses: ./.github/workflows/cra-tests.yaml
     secrets:
       COMPASS_HOST: ${{ secrets.COMPASS_HOST }}
@@ -53,7 +53,7 @@ jobs:
 
   tags:
     needs: [gate]
-    if: needs.gate.result == 'success' || needs.gate.result == 'skipped'
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
       latest: ${{ steps.latest.outputs.latest || '' }}
@@ -61,21 +61,6 @@ jobs:
       - id: latest
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event_name == 'push'
         run: echo "latest=latest" >> $GITHUB_OUTPUT
-
-  k3d-PR-integration:
-    # we're using reusable because we can't modify workflows as contributors
-    # it could cause the secret leakeages
-    uses: "./.github/workflows/reusable-k3d-agent-test.yaml"
-    needs: [build-image]
-    if: needs.build-image.result == 'success'
-    with:
-      k3d-version: v5.8.3
-      cra-image: ${{ fromJSON(needs.build-image.outputs.images)[0] }}
-      artifact-prefix: "pr-"
-    secrets:
-      compass-host: ${{ secrets.COMPASS_HOST }}
-      compass-client-id: ${{ secrets.COMPASS_CLIENT_ID }}
-      compass-client-secret: ${{ secrets.COMPASS_CLIENT_SECRET }}
 
   build-test-image:
     needs: [setup-and-test, gate]
@@ -100,6 +85,21 @@ jobs:
       context: components/compass-runtime-agent
       tags: |
         ${{ needs.tags.outputs.latest }}
+
+  k3d-PR-integration:
+    # we're using reusable because we can't modify workflows as contributors
+    # it could cause the secret leakeages
+    uses: "./.github/workflows/reusable-k3d-agent-test.yaml"
+    needs: [build-image]
+    if: needs.build-image.result == 'success'
+    with:
+      k3d-version: v5.8.3
+      cra-image: ${{ fromJSON(needs.build-image.outputs.images)[0] }}
+      artifact-prefix: "pr-"
+    secrets:
+      compass-host: ${{ secrets.COMPASS_HOST }}
+      compass-client-id: ${{ secrets.COMPASS_CLIENT_ID }}
+      compass-client-secret: ${{ secrets.COMPASS_CLIENT_SECRET }}
 
   print-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/gateway.yaml
+++ b/.github/workflows/gateway.yaml
@@ -42,12 +42,12 @@ jobs:
 
   setup-and-test:
     needs: [gate]
-    if: needs.gate.result == 'success' || needs.gate.result == 'skipped'
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     uses: ./.github/workflows/gateway-tests.yaml
 
   tags:
     needs: [gate]
-    if: needs.gate.result == 'success' || needs.gate.result == 'skipped'
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
       latest: ${{ steps.latest.outputs.latest || '' }}

--- a/.github/workflows/validator.yaml
+++ b/.github/workflows/validator.yaml
@@ -42,12 +42,12 @@ jobs:
 
   setup-and-test:
     needs: [gate]
-    if: needs.gate.result == 'success' || needs.gate.result == 'skipped'
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     uses: ./.github/workflows/validator-tests.yaml
 
   tags:
     needs: [gate]
-    if: needs.gate.result == 'success' || needs.gate.result == 'skipped'
+    if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
       latest: ${{ steps.latest.outputs.latest || '' }}


### PR DESCRIPTION
# Fix Condition to Run Workflow Jobs Dependent on the Gate Job

### Bug Fix

🐛 Fixed incorrect `if` conditions on workflow jobs that depend on the `gate` job. The previous conditions did not account for cancelled workflows, which could cause dependent jobs to be skipped unexpectedly. The fix adds `!cancelled()` to ensure jobs run correctly when the `gate` job either succeeds or is skipped, while still properly handling cancellation scenarios.

### Changes

* `.github/workflows/controller.yaml`: Updated `if` condition on `setup-and-tests` job to use `${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}`.
* `.github/workflows/cra.yaml`: Updated `if` conditions on `setup-and-test` and `tags` jobs with the same fix. Also relocated the `k3d-PR-integration` job to its correct position in the workflow after `build-image`.
* `.github/workflows/gateway.yaml`: Updated `if` conditions on `setup-and-test` and `tags` jobs with the corrected condition.
* `.github/workflows/validator.yaml`: Updated `if` conditions on `setup-and-test` and `tags` jobs with the corrected condition.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `87865eb1-39e0-4183-a5aa-089f4d1b094c`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
