### PR TITLE
Fix cra tests workflow read permissions

### DIFF
--- a/.github/workflows/cra-tests.yaml
+++ b/.github/workflows/cra-tests.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Detect files
         continue-on-error: true
         id: detect-files
-        uses: step-security/changed-files@89030a259c7f36d294c5ad1184fd3ca4a76942de
+        uses: step-security/changed-files@v47
         with:
           files_yaml: |
             cra:

--- a/.github/workflows/cra-tests.yaml
+++ b/.github/workflows/cra-tests.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Detect files
         continue-on-error: true
         id: detect-files
-        uses: step-security/changed-files@v47
+        uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad
         with:
           files_yaml: |
             cra:

--- a/.github/workflows/cra.yaml
+++ b/.github/workflows/cra.yaml
@@ -30,7 +30,6 @@ on:
 permissions:
   id-token: write # This is required for requesting the JWT token
   contents: read # This is required for actions/checkout
-  pull-requests: read # This is required by the setup job in cra-tests.yaml
 
 jobs:
   gate:
@@ -46,6 +45,8 @@ jobs:
   setup-and-test:
     needs: [gate]
     if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
+    permissions:
+      pull-requests: read
     uses: ./.github/workflows/cra-tests.yaml
     secrets:
       COMPASS_HOST: ${{ secrets.COMPASS_HOST }}

--- a/.github/workflows/cra.yaml
+++ b/.github/workflows/cra.yaml
@@ -30,6 +30,7 @@ on:
 permissions:
   id-token: write # This is required for requesting the JWT token
   contents: read # This is required for actions/checkout
+  pull-requests: read # This is required by the setup job in cra-tests.yaml
 
 jobs:
   gate:

--- a/.github/workflows/gateway-tests.yaml
+++ b/.github/workflows/gateway-tests.yaml
@@ -47,7 +47,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Detect files
         id: detect-files
-        uses: step-security/changed-files@89030a259c7f36d294c5ad1184fd3ca4a76942de
+        uses: step-security/changed-files@v47
         with:
           files_yaml: |
             gateway:

--- a/.github/workflows/gateway-tests.yaml
+++ b/.github/workflows/gateway-tests.yaml
@@ -47,7 +47,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Detect files
         id: detect-files
-        uses: step-security/changed-files@v47
+        uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad
         with:
           files_yaml: |
             gateway:

--- a/.github/workflows/validator-tests.yaml
+++ b/.github/workflows/validator-tests.yaml
@@ -48,7 +48,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Detect files
         id: detect-files
-        uses: step-security/changed-files@v47
+        uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad
         with:
           files_yaml: |
             validator:

--- a/.github/workflows/validator-tests.yaml
+++ b/.github/workflows/validator-tests.yaml
@@ -48,7 +48,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Detect files
         id: detect-files
-        uses: step-security/changed-files@89030a259c7f36d294c5ad1184fd3ca4a76942de
+        uses: step-security/changed-files@v47
         with:
           files_yaml: |
             validator:


### PR DESCRIPTION
# Fix CRA Tests Workflow Read Permissions and Update `changed-files` Action Version

### Bug Fix

🐛 Fixes a missing `pull-requests: read` permission in the CRA workflow that was required by the `setup` job in `cra-tests.yaml`. Additionally updates the pinned commit hash reference for the `step-security/changed-files` action to the `v47` tag across multiple workflow files.

### Changes

* `.github/workflows/cra.yaml`: Added `pull-requests: read` permission to the `setup-and-test` job, which calls the reusable `cra-tests.yaml` workflow that requires this permission.
* `.github/workflows/cra-tests.yaml`: Updated `step-security/changed-files` action reference from a pinned commit SHA to `@v47`.
* `.github/workflows/gateway-tests.yaml`: Updated `step-security/changed-files` action reference from a pinned commit SHA to `@v47`.
* `.github/workflows/validator-tests.yaml`: Updated `step-security/changed-files` action reference from a pinned commit SHA to `@v47`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.edited`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Correlation ID: `7ec5535a-c80f-4bd5-93f9-dc3235c1517b`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
