### PR TITLE
Change pull-requests read permission scope in cra workflow

### DIFF
--- a/.github/workflows/cra.yaml
+++ b/.github/workflows/cra.yaml
@@ -30,6 +30,7 @@ on:
 permissions:
   id-token: write # This is required for requesting the JWT token
   contents: read # This is required for actions/checkout
+  pull-requests: read # This is required for setup job in cra-tests.yaml
 
 jobs:
   gate:
@@ -45,8 +46,6 @@ jobs:
   setup-and-test:
     needs: [gate]
     if: ${{ !cancelled() && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
-    permissions:
-      pull-requests: read
     uses: ./.github/workflows/cra-tests.yaml
     secrets:
       COMPASS_HOST: ${{ secrets.COMPASS_HOST }}


### PR DESCRIPTION
# Move `pull-requests: read` Permission to Workflow Level in CRA Workflow

### Refactor

♻️ Refactored the permission scope for `pull-requests: read` in the CRA workflow by moving it from the job-level (`setup-and-test`) to the top-level workflow permissions block.

### Changes

* `.github/workflows/cra.yaml`: Added `pull-requests: read` permission at the workflow level (alongside `id-token: write` and `contents: read`) and removed the previously job-scoped `pull-requests: read` permission from the `setup-and-test` job. This ensures the permission is inherited consistently across all jobs in the workflow, which is required for the setup job in `cra-tests.yaml`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `7bf73972-652b-4200-9984-d4d137bb015a`
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
</details>
