### PR TITLE
Fix govulncheck-action

### DIFF
--- a/.github/workflows/run-vuln-check.yaml
+++ b/.github/workflows/run-vuln-check.yaml
@@ -9,9 +9,6 @@ jobs:
   govuln:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
     - name: vulncheck
       uses: golang/govulncheck-action@v1
       with:


### PR DESCRIPTION
# Fix `govulncheck-action` Workflow

### Bug Fix

🐛 Removed a redundant `actions/checkout` step from the security vulnerability check workflow. The `golang/govulncheck-action` already handles code checkout internally, making the explicit checkout step unnecessary and potentially conflicting.

### Changes

* `.github/workflows/run-vuln-check.yaml`: Removed the `actions/checkout@v6` step, relying on `golang/govulncheck-action@v1` to manage checkout internally.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `a6addba9-e6be-4a6e-bfd5-d1a5157d0cb6`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
</details>
