### PR TITLE
Fix build-image gate: require approval for all PRs, fix skip propagation

### DIFF
--- a/.github/workflows/controller.yaml
+++ b/.github/workflows/controller.yaml
@@ -42,9 +42,7 @@ permissions:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event_name == 'pull_request_target'
     environment: ${{ vars.PROTECTED_ENVIRONMENT }}
     steps:
       - name: Approve fork PR image build
@@ -57,9 +55,7 @@ jobs:
 
   build-image:
     needs: [setup-and-tests, gate]
-    if: >-
-      needs.setup-and-tests.result == 'success' &&
-      (needs.gate.result == 'success' || needs.gate.result == 'skipped')
+    if: ${{ !cancelled() && needs.setup-and-tests.result == 'success' && (needs.gate.result == 'success' || needs.gate.result == 'skipped') }}
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
       name: application-connector-manager


### PR DESCRIPTION
## Summary

- `gate` job now runs for **all** `pull_request_target` events, not just forks — ensures upstream branch PRs also require manual approval before image build
- `build-image` `if` condition wrapped in `${{ !cancelled() && ... }}` — prevents GitHub Actions from silently skipping the reusable workflow job when `gate` is skipped (tag push / main push)

## Problem

When `gate` is skipped (e.g. on tag push), GitHub Actions silently skips `build-image` even though the `if` condition should evaluate to true. This happens because bare `>-` YAML multi-line `if` conditions don't get evaluated properly for skip propagation — only conditions wrapped in `${{ }}` are evaluated correctly.

## Test plan
- [ ] Create a PR from an upstream branch — `gate` job should pause for manual approval
- [ ] After approval, `build-image` should proceed
- [ ] Push a tag — `gate` is skipped, `build-image` should run automatically