### PR TITLE
Skip manual build approval gate for renovate PRs

### DIFF
--- a/.github/workflows/controller.yaml
+++ b/.github/workflows/controller.yaml
@@ -42,10 +42,7 @@ permissions:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
-      github.actor != 'renovate[bot]'
+    if: github.event_name == 'pull_request_target' && github.actor != 'renovate[bot]'
     environment: ${{ vars.PROTECTED_ENVIRONMENT }}
     steps:
       - name: Approve fork PR image build

--- a/.github/workflows/controller.yaml
+++ b/.github/workflows/controller.yaml
@@ -44,7 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      github.actor != 'renovate[bot]'
     environment: ${{ vars.PROTECTED_ENVIRONMENT }}
     steps:
       - name: Approve fork PR image build

--- a/.github/workflows/cra.yaml
+++ b/.github/workflows/cra.yaml
@@ -39,7 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      github.actor != 'renovate[bot]'
     environment: ${{ vars.PROTECTED_ENVIRONMENT }}
     steps:
       - name: Approve fork PR image build

--- a/.github/workflows/cra.yaml
+++ b/.github/workflows/cra.yaml
@@ -37,10 +37,7 @@ permissions:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
-      github.actor != 'renovate[bot]'
+    if: github.event_name == 'pull_request_target' && github.actor != 'renovate[bot]'
     environment: ${{ vars.PROTECTED_ENVIRONMENT }}
     steps:
       - name: Approve fork PR image build

--- a/.github/workflows/gateway.yaml
+++ b/.github/workflows/gateway.yaml
@@ -36,7 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      github.actor != 'renovate[bot]'
     environment: ${{ vars.PROTECTED_ENVIRONMENT }}
     steps:
       - name: Approve fork PR image build

--- a/.github/workflows/gateway.yaml
+++ b/.github/workflows/gateway.yaml
@@ -34,10 +34,7 @@ permissions:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
-      github.actor != 'renovate[bot]'
+    if: github.event_name == 'pull_request_target' && github.actor != 'renovate[bot]'
     environment: ${{ vars.PROTECTED_ENVIRONMENT }}
     steps:
       - name: Approve fork PR image build

--- a/.github/workflows/validator.yaml
+++ b/.github/workflows/validator.yaml
@@ -36,7 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      github.actor != 'renovate[bot]'
     environment: ${{ vars.PROTECTED_ENVIRONMENT }}
     steps:
       - name: Approve fork PR image build

--- a/.github/workflows/validator.yaml
+++ b/.github/workflows/validator.yaml
@@ -34,10 +34,7 @@ permissions:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
-      github.actor != 'renovate[bot]'
+    if: github.event_name == 'pull_request_target' && github.actor != 'renovate[bot]'
     environment: ${{ vars.PROTECTED_ENVIRONMENT }}
     steps:
       - name: Approve fork PR image build


### PR DESCRIPTION
## Summary

- Adds an exception to the `gate` job so that PRs from `renovate[bot]` skip the protected environment approval
- Renovate PRs use same-repo branches (not forks), so they don't carry the untrusted-code risk the gate was designed to prevent
- Downstream jobs already handle a skipped gate via `needs.gate.result == 'skipped'`, so no further changes are needed

## Security note

The `github.actor` value for `renovate[bot]` uses the `[bot]` suffix which is reserved by GitHub for GitHub Apps — it cannot be spoofed by a regular user account.

## Test plan

- [ ] Open a renovate PR and verify the `gate` job is skipped and the build proceeds without manual approval
- [ ] Open a fork PR and verify the `gate` job still requires approval as before

Propagated from kyma-project/kyma-infrastructure-manager#1475