### PR TITLE
Add component-config.yaml

### DIFF
--- a/component-config.yaml
+++ b/component-config.yaml
@@ -1,0 +1,7 @@
+name: kyma-project.io/kyma-runtime/kyma-components/application-connector-manager
+team: kyma/framefrog
+images:
+  - europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:latest
+  - europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:latest
+  - europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:latest
+  - europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:latest


### PR DESCRIPTION
## Summary

This PR adds a `component-config.yaml` file at the repository root, following the pattern established by the `infrastructure-manager` module.

The file lists:
- The component name under the `kyma-project.io/kyma-runtime/kyma-components/` namespace
- The owning team (`kyma/framefrog`)
- All container images produced by this module:
  - `application-connector-manager`
  - `central-application-connectivity-validator`
  - `central-application-gateway`
  - `compass-runtime-agent`

## Motivation

Providing a consistent `component-config.yaml` across Kyma modules enables tooling to discover and track the images associated with each module in a standardised way.