### PR TITLE
Fix invalid `environment` key on reusable-workflow caller jobs

### DIFF
--- a/.github/workflows/cra-tests.yaml
+++ b/.github/workflows/cra-tests.yaml
@@ -142,7 +142,9 @@ jobs:
   k3d-integration:
     # we're using reusable because we can't modify workflows as contributors
     # it could cause the secret leakeages
-    environment: ${{ vars.PROTECTED_ENVIRONMENT }}
+    # NOTE: `environment` is not a valid key on a reusable-workflow caller job.
+    # Environment protection is enforced inside reusable-k3d-agent-test.yaml
+    # (check-protected-environment job + environment on the test job).
     uses: "./.github/workflows/reusable-k3d-agent-test.yaml"
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,6 @@ jobs:
     uses: ./.github/workflows/validator-tests.yaml
 
   run-cra-tests:
-    environment: ${{ vars.PROTECTED_ENVIRONMENT }}
     permissions:
       contents: read
       pull-requests: read  # Required by cra-tests.yaml setup job for changed-files detection


### PR DESCRIPTION
## Problem

PR #896 added `environment: ${{ vars.PROTECTED_ENVIRONMENT }}` to two jobs that call a reusable workflow via `uses:`:
- `k3d-integration` in `.github/workflows/cra-tests.yaml`
- `run-cra-tests` in `.github/workflows/release.yaml`

GitHub Actions does **not** allow the `environment` key on a caller job (a job using `uses:`). The workflow therefore fails to compile:

```
(Line: 146, Col: 5): Unexpected value 'uses'
(Line: 148, Col: 5): Unexpected value 'with'
(Line: 151, Col: 5): Unexpected value 'secrets'
(Line: 145, Col: 5): Required property is missing: runs-on
```

(The parser sees `environment` first, assumes a normal job, then rejects `uses`/`with`/`secrets` and reports `runs-on` missing.)

## Fix

Remove the invalid `environment` key from both caller jobs.

Environment protection is **already enforced inside** `reusable-k3d-agent-test.yaml` — the `check-protected-environment` gate job plus `environment: ${{ vars.PROTECTED_ENVIRONMENT }}` on the `test` job, which is where the compass secrets are actually consumed. So this removes no protection; it only fixes compilation.

## Verification
- `yq` parses both workflows cleanly after the change.