### PR TITLE
chore: bump component images and manifests to 1.3.3

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 ifndef MODULE_VERSION
-    MODULE_VERSION = 1.2.0
+    MODULE_VERSION = 1.3.3
 endif

--- a/application-connector.yaml
+++ b/application-connector.yaml
@@ -274,7 +274,7 @@ spec:
       serviceAccountName: central-application-connectivity-validator
       containers:
         - name: central-application-connectivity-validator
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.2.0
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.3.3
           imagePullPolicy: IfNotPresent
           args:
             - "/app/centralapplicationconnectivityvalidator"
@@ -364,7 +364,7 @@ spec:
       serviceAccountName: central-application-gateway
       containers:
         - name: central-application-gateway
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.2.0
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.3.3
           imagePullPolicy: IfNotPresent
           args:
             - "/app/applicationgateway"
@@ -1057,7 +1057,7 @@ spec:
             - containerPort: 8090
               hostPort: 0
               name: http-health
-          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.2.0
+          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.3.3
           imagePullPolicy: IfNotPresent
           args:
             - "/app/compass-runtime-agent"

--- a/application-connector.yaml
+++ b/application-connector.yaml
@@ -274,7 +274,7 @@ spec:
       serviceAccountName: central-application-connectivity-validator
       containers:
         - name: central-application-connectivity-validator
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.3.3
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.3.2
           imagePullPolicy: IfNotPresent
           args:
             - "/app/centralapplicationconnectivityvalidator"
@@ -364,7 +364,7 @@ spec:
       serviceAccountName: central-application-gateway
       containers:
         - name: central-application-gateway
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.3.3
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.3.2
           imagePullPolicy: IfNotPresent
           args:
             - "/app/applicationgateway"
@@ -1057,7 +1057,7 @@ spec:
             - containerPort: 8090
               hostPort: 0
               name: http-health
-          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.3.3
+          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.3.2
           imagePullPolicy: IfNotPresent
           args:
             - "/app/compass-runtime-agent"

--- a/application-connector.yaml
+++ b/application-connector.yaml
@@ -274,7 +274,7 @@ spec:
       serviceAccountName: central-application-connectivity-validator
       containers:
         - name: central-application-connectivity-validator
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.3.2
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.3.3
           imagePullPolicy: IfNotPresent
           args:
             - "/app/centralapplicationconnectivityvalidator"
@@ -364,7 +364,7 @@ spec:
       serviceAccountName: central-application-gateway
       containers:
         - name: central-application-gateway
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.3.2
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.3.3
           imagePullPolicy: IfNotPresent
           args:
             - "/app/applicationgateway"
@@ -1057,7 +1057,7 @@ spec:
             - containerPort: 8090
               hostPort: 0
               name: http-health
-          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.3.2
+          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.3.3
           imagePullPolicy: IfNotPresent
           args:
             - "/app/compass-runtime-agent"

--- a/config/application-connector-experimental.yaml
+++ b/config/application-connector-experimental.yaml
@@ -598,7 +598,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.3.3-experimental
+        image: europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.3.2-experimental
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/application-connector-experimental.yaml
+++ b/config/application-connector-experimental.yaml
@@ -598,7 +598,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.3.2-experimental
+        image: europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.3.3-experimental
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/application-connector-experimental.yaml
+++ b/config/application-connector-experimental.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   labels:
     kyma-project.io/module: application-connector
   name: applicationconnectors.operator.kyma-project.io
@@ -94,21 +94,16 @@ spec:
                 type: object
               domainName:
                 type: string
+              networkPoliciesEnabled:
+                default: false
+                type: boolean
             type: object
           status:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -149,12 +144,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -251,6 +241,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - secrets
   verbs:
   - create
   - delete
@@ -279,12 +270,6 @@ rules:
   - ""
   resources:
   - nodes
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ""
-  resources:
   - persistentvolumes
   verbs:
   - get
@@ -311,11 +296,6 @@ rules:
   - ""
   resources:
   - serviceaccounts
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
   - services
   verbs:
   - create
@@ -323,17 +303,6 @@ rules:
   - get
   - list
   - patch
-  - update
-  - watch
-- apiGroups:
-  - '*'
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
   - update
   - watch
 - apiGroups:
@@ -412,6 +381,7 @@ rules:
   - networking.istio.io
   resources:
   - gateways
+  - virtualservices
   verbs:
   - create
   - delete
@@ -421,9 +391,9 @@ rules:
   - update
   - watch
 - apiGroups:
-  - networking.istio.io
+  - networking.k8s.io
   resources:
-  - virtualservices
+  - networkpolicies
   verbs:
   - create
   - delete
@@ -463,17 +433,6 @@ rules:
   resources:
   - clusterrolebindings
   - clusterroles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - rolebindings
   - roles
   verbs:
@@ -639,7 +598,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.2.0-experimental
+        image: europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.3.3-experimental
         livenessProbe:
           httpGet:
             path: /healthz
@@ -670,325 +629,3 @@ spec:
         runAsNonRoot: true
       serviceAccountName: application-connector-controller-manager
       terminationGracePeriodSeconds: 10
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-compass-allow-from-health-check
-  namespace: kyma-system
-spec:
-  ingress:
-  - ports:
-    - port: 8090
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      app: compass-runtime-agent
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-gateway-allow-from-cluster-workload
-  namespace: kyma-system
-spec:
-  ingress:
-  - ports:
-    - port: 8080
-      protocol: TCP
-    - port: 8082
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      app: central-application-gateway
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-gateway-allow-from-health-check
-  namespace: kyma-system
-spec:
-  ingress:
-  - ports:
-    - port: 8081
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      app: central-application-gateway
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-gateway-allow-to-external-system
-  namespace: kyma-system
-spec:
-  egress:
-  - ports:
-    - port: 443
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      app: central-application-gateway
-  policyTypes:
-  - Egress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-module-allow-from-sidecar
-  namespace: kyma-system
-spec:
-  ingress:
-  - ports:
-    - port: 15021
-      protocol: TCP
-    - port: 15090
-      protocol: TCP
-  podSelector:
-    matchExpressions:
-    - key: app
-      operator: In
-      values:
-      - application-connector-manager
-      - compass-runtime-agent
-      - central-application-gateway
-      - central-application-connectivity-validator
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-module-allow-metrics
-  namespace: kyma-system
-spec:
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kyma-system
-      podSelector:
-        matchLabels:
-          networking.kyma-project.io/metrics-scraping: allowed
-    ports:
-    - port: 8080
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      app: application-connector-manager
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-module-allow-to-external-system
-  namespace: kyma-system
-spec:
-  egress:
-  - to:
-    - ipBlock:
-        cidr: 0.0.0.0/0
-        except:
-        - 169.254.0.0/16
-  podSelector:
-    matchExpressions:
-    - key: app
-      operator: In
-      values:
-      - compass-runtime-agent
-      - central-application-gateway
-  policyTypes:
-  - Egress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-module-allow-to-sidecar
-  namespace: kyma-system
-spec:
-  egress:
-  - ports:
-    - port: 15012
-      protocol: TCP
-    to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: istio-system
-      podSelector:
-        matchLabels:
-          app.kubernetes.io/name: istiod
-  podSelector:
-    matchExpressions:
-    - key: app
-      operator: In
-      values:
-      - application-connector-manager
-      - compass-runtime-agent
-      - central-application-gateway
-      - central-application-connectivity-validator
-  policyTypes:
-  - Egress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-module-to-api-server
-  namespace: kyma-system
-spec:
-  egress:
-  - ports:
-    - port: 443
-      protocol: TCP
-  podSelector:
-    matchExpressions:
-    - key: app
-      operator: In
-      values:
-      - application-connector-manager
-      - compass-runtime-agent
-      - central-application-gateway
-      - central-application-connectivity-validator
-  policyTypes:
-  - Egress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-module-to-dns
-  namespace: kyma-system
-spec:
-  egress:
-  - ports:
-    - port: 53
-      protocol: UDP
-    - port: 53
-      protocol: TCP
-    to:
-    - ipBlock:
-        cidr: 0.0.0.0/0
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-      podSelector:
-        matchLabels:
-          k8s-app: node-local-dns
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-      podSelector:
-        matchLabels:
-          k8s-app: kube-dns
-  - ports:
-    - port: 8053
-      protocol: UDP
-    - port: 8053
-      protocol: TCP
-    to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-      podSelector:
-        matchLabels:
-          k8s-app: kube-dns
-  podSelector:
-    matchExpressions:
-    - key: app
-      operator: In
-      values:
-      - application-connector-manager
-      - compass-runtime-agent
-      - central-application-gateway
-      - central-application-connectivity-validator
-  policyTypes:
-  - Egress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-validator-allow-from-health-check
-  namespace: kyma-system
-spec:
-  ingress:
-  - ports:
-    - port: 8081
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      app: central-application-connectivity-validator
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-validator-allow-from-istio-ingressgateway
-  namespace: kyma-system
-spec:
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: istio-system
-      podSelector:
-        matchLabels:
-          app.kubernetes.io/name: istio-ingressgateway
-    ports:
-    - port: 8080
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      app: central-application-connectivity-validator
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-validator-allow-to-eventing
-  namespace: kyma-system
-spec:
-  egress:
-  - ports:
-    - port: 8080
-      protocol: TCP
-    to:
-    - podSelector:
-        matchLabels:
-          app.kubernetes.io/name: eventing-publisher-proxy
-  podSelector:
-    matchLabels:
-      app: central-application-connectivity-validator
-  policyTypes:
-  - Egress

--- a/config/application-connector.yaml
+++ b/config/application-connector.yaml
@@ -598,7 +598,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.3.2
+        image: europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.3.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/application-connector.yaml
+++ b/config/application-connector.yaml
@@ -598,7 +598,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.3.3
+        image: europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.3.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/application-connector.yaml
+++ b/config/application-connector.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   labels:
     kyma-project.io/module: application-connector
   name: applicationconnectors.operator.kyma-project.io
@@ -94,21 +94,16 @@ spec:
                 type: object
               domainName:
                 type: string
+              networkPoliciesEnabled:
+                default: false
+                type: boolean
             type: object
           status:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -149,12 +144,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -251,6 +241,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - secrets
   verbs:
   - create
   - delete
@@ -279,12 +270,6 @@ rules:
   - ""
   resources:
   - nodes
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - ""
-  resources:
   - persistentvolumes
   verbs:
   - get
@@ -311,11 +296,6 @@ rules:
   - ""
   resources:
   - serviceaccounts
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
   - services
   verbs:
   - create
@@ -323,17 +303,6 @@ rules:
   - get
   - list
   - patch
-  - update
-  - watch
-- apiGroups:
-  - '*'
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
   - update
   - watch
 - apiGroups:
@@ -412,6 +381,7 @@ rules:
   - networking.istio.io
   resources:
   - gateways
+  - virtualservices
   verbs:
   - create
   - delete
@@ -421,9 +391,9 @@ rules:
   - update
   - watch
 - apiGroups:
-  - networking.istio.io
+  - networking.k8s.io
   resources:
-  - virtualservices
+  - networkpolicies
   verbs:
   - create
   - delete
@@ -463,17 +433,6 @@ rules:
   resources:
   - clusterrolebindings
   - clusterroles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - rolebindings
   - roles
   verbs:
@@ -639,7 +598,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.2.0
+        image: europe-docker.pkg.dev/kyma-project/prod/application-connector-manager:1.3.3
         livenessProbe:
           httpGet:
             path: /healthz
@@ -670,325 +629,3 @@ spec:
         runAsNonRoot: true
       serviceAccountName: application-connector-controller-manager
       terminationGracePeriodSeconds: 10
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-compass-allow-from-health-check
-  namespace: kyma-system
-spec:
-  ingress:
-  - ports:
-    - port: 8090
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      app: compass-runtime-agent
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-gateway-allow-from-cluster-workload
-  namespace: kyma-system
-spec:
-  ingress:
-  - ports:
-    - port: 8080
-      protocol: TCP
-    - port: 8082
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      app: central-application-gateway
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-gateway-allow-from-health-check
-  namespace: kyma-system
-spec:
-  ingress:
-  - ports:
-    - port: 8081
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      app: central-application-gateway
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-gateway-allow-to-external-system
-  namespace: kyma-system
-spec:
-  egress:
-  - ports:
-    - port: 443
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      app: central-application-gateway
-  policyTypes:
-  - Egress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-module-allow-from-sidecar
-  namespace: kyma-system
-spec:
-  ingress:
-  - ports:
-    - port: 15021
-      protocol: TCP
-    - port: 15090
-      protocol: TCP
-  podSelector:
-    matchExpressions:
-    - key: app
-      operator: In
-      values:
-      - application-connector-manager
-      - compass-runtime-agent
-      - central-application-gateway
-      - central-application-connectivity-validator
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-module-allow-metrics
-  namespace: kyma-system
-spec:
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kyma-system
-      podSelector:
-        matchLabels:
-          networking.kyma-project.io/metrics-scraping: allowed
-    ports:
-    - port: 8080
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      app: application-connector-manager
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-module-allow-to-external-system
-  namespace: kyma-system
-spec:
-  egress:
-  - to:
-    - ipBlock:
-        cidr: 0.0.0.0/0
-        except:
-        - 169.254.0.0/16
-  podSelector:
-    matchExpressions:
-    - key: app
-      operator: In
-      values:
-      - compass-runtime-agent
-      - central-application-gateway
-  policyTypes:
-  - Egress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-module-allow-to-sidecar
-  namespace: kyma-system
-spec:
-  egress:
-  - ports:
-    - port: 15012
-      protocol: TCP
-    to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: istio-system
-      podSelector:
-        matchLabels:
-          app.kubernetes.io/name: istiod
-  podSelector:
-    matchExpressions:
-    - key: app
-      operator: In
-      values:
-      - application-connector-manager
-      - compass-runtime-agent
-      - central-application-gateway
-      - central-application-connectivity-validator
-  policyTypes:
-  - Egress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-module-to-api-server
-  namespace: kyma-system
-spec:
-  egress:
-  - ports:
-    - port: 443
-      protocol: TCP
-  podSelector:
-    matchExpressions:
-    - key: app
-      operator: In
-      values:
-      - application-connector-manager
-      - compass-runtime-agent
-      - central-application-gateway
-      - central-application-connectivity-validator
-  policyTypes:
-  - Egress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-module-to-dns
-  namespace: kyma-system
-spec:
-  egress:
-  - ports:
-    - port: 53
-      protocol: UDP
-    - port: 53
-      protocol: TCP
-    to:
-    - ipBlock:
-        cidr: 0.0.0.0/0
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-      podSelector:
-        matchLabels:
-          k8s-app: node-local-dns
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-      podSelector:
-        matchLabels:
-          k8s-app: kube-dns
-  - ports:
-    - port: 8053
-      protocol: UDP
-    - port: 8053
-      protocol: TCP
-    to:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: kube-system
-      podSelector:
-        matchLabels:
-          k8s-app: kube-dns
-  podSelector:
-    matchExpressions:
-    - key: app
-      operator: In
-      values:
-      - application-connector-manager
-      - compass-runtime-agent
-      - central-application-gateway
-      - central-application-connectivity-validator
-  policyTypes:
-  - Egress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-validator-allow-from-health-check
-  namespace: kyma-system
-spec:
-  ingress:
-  - ports:
-    - port: 8081
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      app: central-application-connectivity-validator
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-validator-allow-from-istio-ingressgateway
-  namespace: kyma-system
-spec:
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: istio-system
-      podSelector:
-        matchLabels:
-          app.kubernetes.io/name: istio-ingressgateway
-    ports:
-    - port: 8080
-      protocol: TCP
-  podSelector:
-    matchLabels:
-      app: central-application-connectivity-validator
-  policyTypes:
-  - Ingress
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  labels:
-    kyma-project.io/module: application-connector
-  name: application-connector-kyma-project.io--acm-validator-allow-to-eventing
-  namespace: kyma-system
-spec:
-  egress:
-  - ports:
-    - port: 8080
-      protocol: TCP
-    to:
-    - podSelector:
-        matchLabels:
-          app.kubernetes.io/name: eventing-publisher-proxy
-  podSelector:
-    matchLabels:
-      app: central-application-connectivity-validator
-  policyTypes:
-  - Egress

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: europe-docker.pkg.dev/kyma-project/prod/application-connector-manager
-  newTag: 1.2.0-experimental
+  newName: k3d-kyma-registry:5001/appcon-manager-dev-local
+  newTag: 0.0.1

--- a/pkg/reconciler/testdata/update/acm-valid.yaml
+++ b/pkg/reconciler/testdata/update/acm-valid.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: central-application-connectivity-validator
       containers:
         - name: central-application-connectivity-validator
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.3.2
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.3.3
           imagePullPolicy: IfNotPresent
           args:
             - "/app/centralapplicationconnectivityvalidator"
@@ -126,7 +126,7 @@ spec:
       serviceAccountName: central-application-gateway
       containers:
         - name: central-application-gateway
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.3.2
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.3.3
           imagePullPolicy: IfNotPresent
           args:
             - "/app/applicationgateway"
@@ -218,7 +218,7 @@ spec:
             - containerPort: 8090
               hostPort: 0
               name: http-health
-          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.3.2
+          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.3.3
           imagePullPolicy: IfNotPresent
           args:
             - "/app/compass-runtime-agent"

--- a/pkg/reconciler/testdata/update/acm-valid.yaml
+++ b/pkg/reconciler/testdata/update/acm-valid.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: central-application-connectivity-validator
       containers:
         - name: central-application-connectivity-validator
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.3.3
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.3.2
           imagePullPolicy: IfNotPresent
           args:
             - "/app/centralapplicationconnectivityvalidator"
@@ -126,7 +126,7 @@ spec:
       serviceAccountName: central-application-gateway
       containers:
         - name: central-application-gateway
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.3.3
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.3.2
           imagePullPolicy: IfNotPresent
           args:
             - "/app/applicationgateway"
@@ -218,7 +218,7 @@ spec:
             - containerPort: 8090
               hostPort: 0
               name: http-health
-          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.3.3
+          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.3.2
           imagePullPolicy: IfNotPresent
           args:
             - "/app/compass-runtime-agent"

--- a/pkg/reconciler/testdata/update/acm-valid.yaml
+++ b/pkg/reconciler/testdata/update/acm-valid.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: central-application-connectivity-validator
       containers:
         - name: central-application-connectivity-validator
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.2.0
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-connectivity-validator:1.3.3
           imagePullPolicy: IfNotPresent
           args:
             - "/app/centralapplicationconnectivityvalidator"
@@ -126,7 +126,7 @@ spec:
       serviceAccountName: central-application-gateway
       containers:
         - name: central-application-gateway
-          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.2.0
+          image: europe-docker.pkg.dev/kyma-project/prod/central-application-gateway:1.3.3
           imagePullPolicy: IfNotPresent
           args:
             - "/app/applicationgateway"
@@ -218,7 +218,7 @@ spec:
             - containerPort: 8090
               hostPort: 0
               name: http-health
-          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.2.0
+          image: europe-docker.pkg.dev/kyma-project/prod/compass-runtime-agent:1.3.3
           imagePullPolicy: IfNotPresent
           args:
             - "/app/compass-runtime-agent"


### PR DESCRIPTION
## Summary
Update component images from 1.2.0 to 1.3.3:
- `central-application-connectivity-validator`
- `central-application-gateway`
- `compass-runtime-agent`
- `application-connector-manager`

Also updates `MODULE_VERSION` in `.env` to 1.3.3.

## Changed files
- `.env` - MODULE_VERSION bump
- `application-connector.yaml` - 3 component image tags
- `pkg/reconciler/testdata/update/acm-valid.yaml` - 3 component image tags (test data)
- `config/application-connector.yaml` - manager image + regenerated manifests
- `config/application-connector-experimental.yaml` - manager image + regenerated manifests

## Related
Part of ACM 1.3.3 release