### PR TITLE
Fix cache namespace scope: add istio-system and kube-system

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,7 +78,8 @@ func main() {
 		LeaderElectionID:       "3e432b4e.acm.operator.kyma-project.io",
 		Cache: cache.Options{
 			DefaultNamespaces: map[string]cache.Config{
-				"kyma-system": {},
+				"kyma-system":  {},
+				"istio-system": {},
 			},
 		},
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func main() {
 			DefaultNamespaces: map[string]cache.Config{
 				"kyma-system":  {},
 				"istio-system": {},
+				"kube-system":  {},
 			},
 		},
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
@@ -100,7 +101,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("created controller manager for kyma-system namespace")
+	setupLog.Info("created controller manager for kyma-system, istio-system and kube-system namespaces")
 
 	file, err := os.Open("application-connector.yaml")
 


### PR DESCRIPTION
## Problem

PR #932 scoped the controller-runtime cache to `kyma-system` only. After a thorough audit of all namespace accesses in the controller code and manifests, two additional namespaces are required.

`multiNamespaceCache.Get` and `multiNamespaceCache.List` return a **hard error** for any namespace not in `DefaultNamespaces` when no `NamespaceAll` fallback is present:
```
unable to get: <key> because of unknown namespace for the cache
```
This means omitting these namespaces is a correctness bug, not just a performance concern.

## Missing namespaces

### `istio-system`
The controller applies and manages two namespace-scoped resources there (from `application-connector.yaml`):
- `compass-runtime-agent-ca-cert-role` — Role
- `compass-runtime-agent-ca-cert-rolebinding` — RoleBinding

These flow through `sFnApply`, `sFnVerify`, and `sFnDeleteResources → deleteResourcesWithFilter → r.Delete`. The deletion path also calls `listDependencies → m.List` which goes through the cache.

### `kube-system`
`sFnDetectDomain` reads the Gardener `shoot-info` ConfigMap via `r.Get` to detect the cluster domain name (`detect_domain.go:29`). Without `kube-system` in the cache this call fails on every reconciliation where `DomainName` is not set in the CR spec.

## Full namespace inventory

| Namespace | Used by | What |
|---|---|---|
| `kyma-system` | all manifests, reconciler | primary namespace for all managed resources |
| `istio-system` | `application-connector.yaml:927,992` | ca-cert Role + RoleBinding for compass-runtime-agent |
| `kube-system` | `detect_domain.go:29` | `r.Get` on `shoot-info` ConfigMap (Gardener domain detection) |

No other namespaces are accessed anywhere in the controller codebase.