### PR TITLE
Skip CodeQL Analyze (go) in all-checks-passed workflow

### DIFF
--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - uses: wechuli/allcheckspassed@1d00cf0c34c4b0805db8866d8913f22e7125301e
         with:
+          checks_exclude: 'Analyze \(go\)'
           delay: '3'
           retries: '30'
           polling_interval: '1'


### PR DESCRIPTION
The dynamic CodeQL `Analyze (go)` check is excluded from the `all-checks-passed` gate.

## Problem
The `wechuli/allcheckspassed` action fails when `Analyze (go)` fails (e.g. when CodeQL autobuild can't compile the project), blocking PR merges even for unrelated changes.

## Change
Added `Analyze \(go\)` to `checks_exclude` in the `all-checks-passed` workflow. The `Analyze (actions)` check remains enforced.