### PR TITLE
Replace deprecated Requeue bool with RequeueAfter

### DIFF
--- a/controllers/applicationconnector_controller.go
+++ b/controllers/applicationconnector_controller.go
@@ -256,9 +256,7 @@ var requCounter = 0
 func (r *applicationConnectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var instance v1alpha1.ApplicationConnector
 	if err := r.Get(ctx, req.NamespacedName, &instance); err != nil {
-		return ctrl.Result{
-			Requeue: true,
-		}, client.IgnoreNotFound(err)
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	stateFSM := reconciler.NewFsm(

--- a/pkg/reconciler/common.go
+++ b/pkg/reconciler/common.go
@@ -18,7 +18,7 @@ func stopWithNoRequeue() (stateFn, *ctrl.Result, error) {
 }
 
 func stopWithRequeue() (stateFn, *ctrl.Result, error) {
-	return sFnUpdateStatus(&ctrl.Result{Requeue: true}, nil), nil, nil
+	return sFnUpdateStatus(&ctrl.Result{RequeueAfter: time.Second}, nil), nil, nil
 }
 
 func switchState(fn stateFn) (stateFn, *ctrl.Result, error) {

--- a/pkg/reconciler/fsm.go
+++ b/pkg/reconciler/fsm.go
@@ -82,9 +82,7 @@ loop:
 		return *result, err
 	}
 
-	return ctrl.Result{
-		Requeue: false,
-	}, err
+	return ctrl.Result{}, err
 }
 
 func NewFsm(log *zap.SugaredLogger, cfg Cfg, k8s K8s, depsACK *bool) Fsm {

--- a/pkg/reconciler/remove_finalizer.go
+++ b/pkg/reconciler/remove_finalizer.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,7 +14,7 @@ func sFnRemoveFinalizer(ctx context.Context, r *fsm, s *systemState) (stateFn, *
 
 	err := r.Update(ctx, &s.instance)
 	if client.IgnoreNotFound(err) != nil {
-		return nil, &ctrl.Result{Requeue: true}, err
+		return nil, &ctrl.Result{RequeueAfter: time.Second}, err
 	}
 
 	r.log.Debug("finalizer removed")


### PR DESCRIPTION
## Description

Migrates all usages of the deprecated `ctrl.Result{Requeue: true/false}` to use `RequeueAfter` or an empty `ctrl.Result{}`, as recommended by controller-runtime v0.24.1.

From the [controller-runtime deprecation notice](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.24.1/pkg/reconcile#Result):

> This setting is deprecated as it causes confusion and there is no good reason to use it. When waiting for an external event to happen, either the duration until it is supposed to happen or an appropriate poll interval should be used, rather than an interval emitted by a ratelimiter whose purpose it is to control retry on error.

## Changes

| File | Before | After | Rationale |
|------|--------|-------|-----------|
| `controllers/applicationconnector_controller.go` | `ctrl.Result{Requeue: true}, client.IgnoreNotFound(err)` | `ctrl.Result{}, client.IgnoreNotFound(err)` | NotFound → nil error, no requeue needed. Other errors trigger requeue via error return. |
| `pkg/reconciler/common.go` | `stopWithRequeue()` → `Requeue: true` | `RequeueAfter: time.Second` | Short delay for quick re-reconciliation (after init, watch registration, deletion state update). |
| `pkg/reconciler/remove_finalizer.go` | `Requeue: true` with error | `RequeueAfter: time.Second` with error | Explicit retry interval instead of rate-limiter-controlled. |
| `pkg/reconciler/fsm.go` | `ctrl.Result{Requeue: false}` | `ctrl.Result{}` | Remove explicit zero-value field. |

## Why 1 second for `stopWithRequeue()`?

The `stopWithRequeue()` helper is used in cases where the reconciler needs a quick retry after a state transition (e.g., after adding a finalizer or registering a dependency watch). A 1-second delay gives the system time to propagate changes without relying on the workqueue rate limiter's opaque backoff behavior.

## Related

- controller-runtime deprecation: https://github.com/kubernetes-sigs/controller-runtime/pull/2995